### PR TITLE
split string tags parameter

### DIFF
--- a/app/services/socks_selector.rb
+++ b/app/services/socks_selector.rb
@@ -9,7 +9,8 @@ class SocksSelector
   end
 
   def call
-    @socks = [];
+    @socks = []
+    @tags = @tags.split(',')
     if @tags.length > 0
       @socks = Sock.all.filter {
         |sock| @tags.find { |tag| tag == Tag.find(SockTag.find_by(sock_id: sock.sock_id).tag_id).name }


### PR DESCRIPTION
## 変更内容
https://onenr.io/04ERPmNq6jW

該当のエラーを見ていると String でパラメーターが入ってきているがエラーの起きている sock_selector.rb は配列で入ってくることを想定しているので split メソッドを利用して文字列を配列に変換する処理を追加しました。